### PR TITLE
Fix: Negatives temperatures are not correctly returned.

### DIFF
--- a/aosong/am2315.py
+++ b/aosong/am2315.py
@@ -127,7 +127,7 @@ class Sensor:
 		# 16-Sep-2014
 		# Thanks to Ethan for pointing out this bug!
 		# ethansimpson@xtra.co.nz
-        if temp_H&0x08:
+        if temp_H&0x80:
            negative = True
         # Mask the negative flag
         temp_H &=0x7F


### PR DESCRIPTION
Issue:
When the temperature is negative, the absolute value of the real temperature is returned:
If the temperature is -3°C the method temperature() still returns 3°C.

The negative temperature was not correctly detected: now we test the correct bit to know if the temperature is negative or not.
The same bit is checked in this repo: https://github.com/adafruit/Adafruit_AM2315 in Adafruit_AM2315.cpp:
```c 
// change sign
  if (reply[4] >> 7) temp = -temp;
```